### PR TITLE
dK2scaled now returns real (the intended type)

### DIFF
--- a/source/HEG.f90
+++ b/source/HEG.f90
@@ -1019,7 +1019,8 @@ contains
 
         Logical, Intent(InOut) :: InCore
 
-        Integer :: this_qvec(3), this_qvec2
+        Integer :: this_qvec(3)
+        Real (Kind=pr) this_qvec2
 
         this_qvec=-HEGData%nvec(i,:)+HEGData%nvec(a,:)
         this_qvec2=dot_product(this_qvec,this_qvec)


### PR DESCRIPTION
This simple patch fixes a bug that likely got introduced when refactoring the code to remove global data.
The return type for the dK2scaled function was int, when it should have been float.